### PR TITLE
Tiles extraction with check_tissue=False is performed within the tissue box

### DIFF
--- a/src/histolab/tiler.py
+++ b/src/histolab/tiler.py
@@ -216,8 +216,6 @@ class RandomTiler(Tiler):
 
         while True:
 
-            iteration += 1
-
             tile_wsi_coords = self._random_tile_coordinates(slide)
             try:
                 tile = slide.extract_tile(tile_wsi_coords, self.level)
@@ -228,11 +226,12 @@ class RandomTiler(Tiler):
             if not self.check_tissue or tile.has_enough_tissue():
                 yield tile, tile_wsi_coords
                 valid_tile_counter += 1
+            iteration += 1
 
-            if self.max_iter and iteration > self.max_iter:
+            if self.max_iter and iteration >= self.max_iter:
                 break
 
-            if valid_tile_counter > self.n_tiles:
+            if valid_tile_counter >= self.n_tiles:
                 break
 
     def _tile_filename(

--- a/src/histolab/tiler.py
+++ b/src/histolab/tiler.py
@@ -101,9 +101,7 @@ class RandomTiler(Tiler):
     def box_mask(self, slide: Slide) -> sparse._coo.core.COO:
         """Return binary mask at level 0 of the box to consider for tiles extraction.
 
-        If `check_tissue` attribute is True, the mask pixels set to True will be the
-        ones corresponding to the tissue box. Otherwise, all the mask pixels will be set
-        to True.
+        The mask pixels set to True will be the ones corresponding to the tissue box.
 
         Parameters
         ----------
@@ -116,18 +114,13 @@ class RandomTiler(Tiler):
             Extraction mask at level 0
         """
 
-        if self.check_tissue:
-            return slide.biggest_tissue_box_mask
-        else:
-            return sparse.ones(slide.dimensions[::-1], dtype=bool)
+        return slide.biggest_tissue_box_mask
 
     @lru_cache(maxsize=100)
     def box_mask_lvl(self, slide: Slide) -> sparse._coo.core.COO:
         """Return binary mask at target level of the box to consider for the extraction.
 
-        If ``check_tissue`` attribute is True, the mask pixels set to True will be the
-        ones corresponding to the tissue box. Otherwise, all the mask pixels will be set
-        to True.
+        The mask pixels set to True will be the ones corresponding to the tissue box.
 
         Parameters
         ----------

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -152,7 +152,7 @@ class Describe_RandomTiler(object):
     @pytest.mark.parametrize(
         "check_tissue, expected_box",
         (
-            (False, SparseArrayMock.ONES_500X500_BOOL),
+            (False, SparseArrayMock.RANDOM_500X500_BOOL),
             (True, SparseArrayMock.RANDOM_500X500_BOOL),
         ),
     )
@@ -165,14 +165,12 @@ class Describe_RandomTiler(object):
         _biggest_tissue_box_mask = property_mock(
             request, Slide, "biggest_tissue_box_mask"
         )
-        if check_tissue:
-            _biggest_tissue_box_mask.return_value = expected_box
+        _biggest_tissue_box_mask.return_value = expected_box
         random_tiler = RandomTiler((128, 128), 10, 0, check_tissue=check_tissue)
 
         box_mask = random_tiler.box_mask(slide)
 
-        if check_tissue:
-            _biggest_tissue_box_mask.assert_called_once_with()
+        _biggest_tissue_box_mask.assert_called_once_with()
         assert type(box_mask) == sparse._coo.core.COO
         np.testing.assert_array_almost_equal(box_mask.todense(), expected_box.todense())
 


### PR DESCRIPTION
Even with check_tissue=False, the tiles will be extracted within the tissue box
Fix #100 

Fix bug with the number of tiles returned from the random tiler (one more than expected)
Fix #108 