### PR TITLE
Augment report using pytest-html and custom helpers

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ sphinx-rtd-theme
 ipdb
 isort
 sphinxcontrib-katex
+pytest-html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+# encoding: utf-8
+
+"""Utilities for pytest reports."""
+
+import pytest
+import PIL
+
+from .util import pil_to_base64
+
+
+class HTMLRenderer:
+    """HTML object for rendering header and body on the pytest html report."""
+
+    def __init__(self, items):
+        self._keys = items.keys()
+        self._values = items.values()
+
+    @property
+    def body(self):
+        """Table body for the html report."""
+        return "".join([f"<td>{self._html_tag(item)}</td>" for item in self._values])
+
+    @property
+    def head(self):
+        """Table header for the html report."""
+        return "".join([f"<th>{item.title()}</th>" for item in self._keys])
+
+    @staticmethod
+    def _html_tag(item):
+        """Convert the given item in a proper html tag."""
+        if isinstance(item, PIL.Image.Image):
+            return f"<img src='data:image/png;base64,{pil_to_base64(item)}'>"
+        return item
+
+
+@pytest.mark.hookwrapper
+def pytest_runtest_makereport(item):
+    pytest_html = item.config.pluginmanager.getplugin("html")
+    outcome = yield
+    report = outcome.get_result()
+    extra = getattr(report, "extra", [])
+    if report.when == "call" and report.failed:
+        extra_args = getattr(item, "extra_args", None)
+        html = HTMLRenderer(extra_args)
+        if extra_args:
+            extra.append(
+                pytest_html.extras.html(
+                    f"""
+                    <table width=100%>
+                        <thead><tr>{html.head}</tr></thead>
+                        <tbody><tr>{html.body}</tr><tbody>
+                    </table>
+                    """
+                )
+            )
+        report.extra = extra

--- a/tests/integration/test_slide.py
+++ b/tests/integration/test_slide.py
@@ -59,44 +59,44 @@ class Describe_Slide:
         )
 
     @pytest.mark.parametrize(
-        "slide_fixture, tissue_mask, expectation",
+        "slide_fixture, tissue_mask, save_scaled_image, expectation",
         [
             (
                 SVS.CMU_1_SMALL_REGION,
                 True,
-                "bbox-location-images/"
+                True,
                 "cmu-1-small-region-bbox-location-tissue-mask-true",
             ),
             (
                 SVS.CMU_1_SMALL_REGION,
                 False,
-                "bbox-location-images/"
+                True,
                 "cmu-1-small-region-bbox-location-tissue-mask-false",
             ),
             (
                 SVS.TCGA_CR_7395_01A_01_TS1,
                 True,
-                "bbox-location-images/"
+                False,
                 "tcga-cr-7395-01a-01-ts1-bbox-location-tissue-mask-true",
             ),
             (
                 SVS.TCGA_CR_7395_01A_01_TS1,
                 False,
-                "bbox-location-images/"
+                False,
                 "tcga-cr-7395-01a-01-ts1-bbox-location-tissue-mask-false",
             ),
         ],
     )
     def it_locates_the_biggest_bbox(
-        self, tmpdir, slide_fixture, tissue_mask, expectation
+        self, tmpdir, slide_fixture, tissue_mask, save_scaled_image, expectation
     ):
         slide = Slide(slide_fixture, os.path.join(tmpdir, "processed"))
-        slide.save_scaled_image(3)
+        if save_scaled_image:
+            slide.save_scaled_image(3)
         expected_img = load_expectation(
-            expectation,
+            os.path.join("bbox-location-images", expectation),
             type_="png",
         )
-
         bbox_location_img = slide.locate_biggest_tissue_box(
             tissue_mask=tissue_mask, scale_factor=3
         )

--- a/tests/integration/test_tiler.py
+++ b/tests/integration/test_tiler.py
@@ -10,7 +10,7 @@ from histolab.slide import Slide
 from histolab.tiler import GridTiler, RandomTiler, ScoreTiler
 
 from ..fixtures import SVS
-from ..util import load_expectation
+from ..util import load_expectation, expand_tests_report
 
 
 class DescribeRandomTiler:
@@ -27,7 +27,9 @@ class DescribeRandomTiler:
             ),
         ],
     )
-    def it_locates_tiles_on_the_slide(self, fixture_slide, expectation, tmpdir):
+    def it_locates_tiles_on_the_slide(
+        self, request, fixture_slide, expectation, tmpdir
+    ):
         slide = Slide(fixture_slide, os.path.join(tmpdir, "processed"))
         slide.save_scaled_image(10)
         random_tiles_extractor = RandomTiler(
@@ -38,6 +40,8 @@ class DescribeRandomTiler:
             type_="png",
         )
         tiles_location_img = random_tiles_extractor.locate_tiles(slide, scale_factor=10)
+        # --- Expanding test report with actual and expected images ---
+        expand_tests_report(request, actual=tiles_location_img, expected=expectation)
 
         np.testing.assert_array_almost_equal(
             np.asarray(tiles_location_img), expected_img
@@ -58,7 +62,9 @@ class DescribeGridTiler:
             ),
         ],
     )
-    def it_locates_tiles_on_the_slide(self, fixture_slide, expectation, tmpdir):
+    def it_locates_tiles_on_the_slide(
+        self, request, fixture_slide, expectation, tmpdir
+    ):
         slide = Slide(fixture_slide, os.path.join(tmpdir, "processed"))
         grid_tiles_extractor = GridTiler(
             tile_size=(512, 512),
@@ -67,6 +73,8 @@ class DescribeGridTiler:
         )
         expected_img = load_expectation(expectation, type_="png")
         tiles_location_img = grid_tiles_extractor.locate_tiles(slide, scale_factor=10)
+        # --- Expanding test report with actual and expected images ---
+        expand_tests_report(request, expected=expectation, actual=tiles_location_img)
 
         np.testing.assert_array_almost_equal(
             np.asarray(tiles_location_img), expected_img
@@ -87,7 +95,9 @@ class DescribeScoreTiler:
             ),
         ],
     )
-    def it_locates_tiles_on_the_slide(self, fixture_slide, expectation, tmpdir):
+    def it_locates_tiles_on_the_slide(
+        self, request, fixture_slide, expectation, tmpdir
+    ):
         slide = Slide(fixture_slide, os.path.join(tmpdir, "processed"))
         scored_tiles_extractor = ScoreTiler(
             scorer=NucleiScorer(),
@@ -100,10 +110,10 @@ class DescribeScoreTiler:
             expectation,
             type_="png",
         )
-        scored_location_img = scored_tiles_extractor.locate_tiles(
-            slide, scale_factor=10
-        )
+        tiles_location_img = scored_tiles_extractor.locate_tiles(slide, scale_factor=10)
+        # --- Expanding test report with actual and expected images ---
+        expand_tests_report(request, expected=expectation, actual=tiles_location_img)
 
         np.testing.assert_array_almost_equal(
-            np.asarray(scored_location_img), expected_img
+            np.asarray(tiles_location_img), expected_img
         )

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,10 +2,25 @@
 
 """Utilities for histolab tests."""
 
+import base64
 import os
+
+from io import BytesIO
 
 import numpy as np
 from PIL import Image
+
+
+def pil_to_base64(pilimage):  # pragma: no cover
+    """Returns base64 encoded image given a PIL Image"""
+    buffer = BytesIO()
+    pilimage.save(buffer, "png")
+    return base64.b64encode(buffer.getvalue()).decode()
+
+
+def expand_tests_report(request, **kwargs):  # pragma: no cover
+    """Augment request with key value args that will be passed to pytest markreport."""
+    setattr(request.node, "extra_args", kwargs)
 
 
 def load_expectation(expectation_file_name, type_=None):  # pragma: no cover


### PR DESCRIPTION
Augment test report for TDD actions.

In tests now `expand_tests_report(request, kwargs)` can be used to create a more detailed report like

![image](https://user-images.githubusercontent.com/4196091/101224478-00687100-368f-11eb-9f1f-0d8e4146aee6.png)

This requires `pytest-html` and the test suite must be ran with this command:

```bash
pytest -svv tests --html=test-report.html --self-contained-html --capture=tee-sys
```

This command will generate an html file with the given name in the directory you're running `pytest` command.

This feature will be very useful for future development when on an integration test we wanna compare the actual and the expected result using real images instead of arrays or expressions.