### PR TITLE
Raise TileSizeError if the tile size is larger than the slide size

### DIFF
--- a/src/histolab/exceptions.py
+++ b/src/histolab/exceptions.py
@@ -39,3 +39,7 @@ class LevelError(HistolabException):
 
 class FilterCompositionError(HistolabException):
     """Raised when a filter composition for the class is not available"""
+
+
+class TileSizeError(HistolabException):
+    """Raised when the tile size is larger than the slide size"""

--- a/src/histolab/tiler.py
+++ b/src/histolab/tiler.py
@@ -25,7 +25,7 @@ from typing import List, Tuple
 import numpy as np
 import PIL
 
-from .exceptions import LevelError
+from .exceptions import LevelError, TileSizeError
 from .scorer import Scorer
 from .slide import Slide
 from .tile import Tile
@@ -188,11 +188,25 @@ class GridTiler(Tiler):
         ----------
         slide : Slide
             Slide from which to extract the tiles
+
+        Raises
+        ------
+        TileSizeError
+            If the tile size is larger than the slide size
         """
         if self.level not in slide.levels:
             raise LevelError(
                 f"Level {self.level} not available. Number of available levels: "
                 f"{len(slide.levels)}"
+            )
+
+        if (
+            self.tile_size[0] > slide.level_dimensions(self.level)[0]
+            or self.tile_size[1] > slide.level_dimensions(self.level)[1]
+        ):
+            raise TileSizeError(
+                f"Tile size {self.tile_size} is larger than slide size "
+                f"{slide.level_dimensions(self.level)} at level {self.level}"
             )
 
         grid_tiles = self._tiles_generator(slide)
@@ -422,7 +436,21 @@ class RandomTiler(Tiler):
         ----------
         slide : Slide
             Slide from which to extract the tiles
+
+        Raises
+        ------
+        TileSizeError
+            If the tile size is larger than the slide size
         """
+        if (
+            self.tile_size[0] > slide.level_dimensions(self.level)[0]
+            or self.tile_size[1] > slide.level_dimensions(self.level)[1]
+        ):
+            raise TileSizeError(
+                f"Tile size {self.tile_size} is larger than slide size "
+                f"{slide.level_dimensions(self.level)} at level {self.level}"
+            )
+
         random_tiles = self._tiles_generator(slide)
 
         tiles_counter = 0
@@ -618,7 +646,21 @@ class ScoreTiler(GridTiler):
             Slide from which to extract the tiles
         report_path : str, optional
             Path to the CSV report. If None, no report will be saved
+
+        Raises
+        ------
+        TileSizeError
+            If the tile size is larger than the slide size
         """
+        if (
+            self.tile_size[0] > slide.level_dimensions(self.level)[0]
+            or self.tile_size[1] > slide.level_dimensions(self.level)[1]
+        ):
+            raise TileSizeError(
+                f"Tile size {self.tile_size} is larger than slide size "
+                f"{slide.level_dimensions(self.level)} at level {self.level}"
+            )
+
         highest_score_tiles, highest_scaled_score_tiles = self._highest_score_tiles(
             slide
         )

--- a/src/histolab/tiler.py
+++ b/src/histolab/tiler.py
@@ -105,6 +105,25 @@ class Tiler(Protocol):
 
     # ------- implementation helpers -------
 
+    def _has_valid_tile_size(self, slide: Slide) -> bool:
+        """Return True if the tile size is smaller or equal than the ``slide`` size.
+
+        Parameters
+        ----------
+        slide : Slide
+            The slide to check the tile size against.
+
+        Returns
+        -------
+        bool
+            True if the tile size is smaller or equal than the ``slide`` size at
+            extraction level, False otherwise
+        """
+        return (
+            self.tile_size[0] <= slide.level_dimensions(self.level)[0]
+            and self.tile_size[1] <= slide.level_dimensions(self.level)[1]
+        )
+
     def _tile_filename(
         self, tile_wsi_coords: CoordinatePair, tiles_counter: int
     ) -> str:
@@ -134,25 +153,6 @@ class Tiler(Protocol):
 
     def _tiles_generator(self, slide: Slide) -> Tuple[Tile, CoordinatePair]:
         raise NotImplementedError
-
-    def _has_valid_tile_size(self, slide: Slide) -> bool:
-        """Return True if the tile size is smaller or equal than the ``slide`` size.
-
-        Parameters
-        ----------
-        slide : Slide
-            The slide to check the tile size against.
-
-        Returns
-        -------
-        bool
-            True if the tile size is smaller or equal than the ``slide`` size at
-            extraction level, False otherwise
-        """
-        return (
-            self.tile_size[0] <= slide.level_dimensions(self.level)[0]
-            and self.tile_size[1] <= slide.level_dimensions(self.level)[1]
-        )
 
 
 class GridTiler(Tiler):

--- a/src/histolab/tiler.py
+++ b/src/histolab/tiler.py
@@ -193,6 +193,8 @@ class GridTiler(Tiler):
         ------
         TileSizeError
             If the tile size is larger than the slide size
+        LevelError
+            If the level is not available for the slide
         """
         if self.level not in slide.levels:
             raise LevelError(
@@ -441,7 +443,14 @@ class RandomTiler(Tiler):
         ------
         TileSizeError
             If the tile size is larger than the slide size
+        LevelError
+            If the level is not available for the slide
         """
+        if self.level not in slide.levels:
+            raise LevelError(
+                f"Level {self.level} not available. Number of available levels: "
+                f"{len(slide.levels)}"
+            )
         if (
             self.tile_size[0] > slide.level_dimensions(self.level)[0]
             or self.tile_size[1] > slide.level_dimensions(self.level)[1]
@@ -651,7 +660,14 @@ class ScoreTiler(GridTiler):
         ------
         TileSizeError
             If the tile size is larger than the slide size
+        LevelError
+            If the level is not available for the slide
         """
+        if self.level not in slide.levels:
+            raise LevelError(
+                f"Level {self.level} not available. Number of available levels: "
+                f"{len(slide.levels)}"
+            )
         if (
             self.tile_size[0] > slide.level_dimensions(self.level)[0]
             or self.tile_size[1] > slide.level_dimensions(self.level)[1]

--- a/src/histolab/tiler.py
+++ b/src/histolab/tiler.py
@@ -135,6 +135,25 @@ class Tiler(Protocol):
     def _tiles_generator(self, slide: Slide) -> Tuple[Tile, CoordinatePair]:
         raise NotImplementedError
 
+    def _has_valid_tile_size(self, slide: Slide) -> bool:
+        """Return True if the tile size is smaller or equal than the ``slide`` size.
+
+        Parameters
+        ----------
+        slide : Slide
+            The slide to check the tile size against.
+
+        Returns
+        -------
+        bool
+            True if the tile size is smaller or equal than the ``slide`` size at
+            extraction level, False otherwise
+        """
+        return (
+            self.tile_size[0] <= slide.level_dimensions(self.level)[0]
+            and self.tile_size[1] <= slide.level_dimensions(self.level)[1]
+        )
+
 
 class GridTiler(Tiler):
     """Extractor of tiles arranged in a grid, at the given level, with the given size.
@@ -202,10 +221,7 @@ class GridTiler(Tiler):
                 f"{len(slide.levels)}"
             )
 
-        if (
-            self.tile_size[0] > slide.level_dimensions(self.level)[0]
-            or self.tile_size[1] > slide.level_dimensions(self.level)[1]
-        ):
+        if not self._has_valid_tile_size(slide):
             raise TileSizeError(
                 f"Tile size {self.tile_size} is larger than slide size "
                 f"{slide.level_dimensions(self.level)} at level {self.level}"
@@ -451,10 +467,7 @@ class RandomTiler(Tiler):
                 f"Level {self.level} not available. Number of available levels: "
                 f"{len(slide.levels)}"
             )
-        if (
-            self.tile_size[0] > slide.level_dimensions(self.level)[0]
-            or self.tile_size[1] > slide.level_dimensions(self.level)[1]
-        ):
+        if not self._has_valid_tile_size(slide):
             raise TileSizeError(
                 f"Tile size {self.tile_size} is larger than slide size "
                 f"{slide.level_dimensions(self.level)} at level {self.level}"
@@ -668,10 +681,7 @@ class ScoreTiler(GridTiler):
                 f"Level {self.level} not available. Number of available levels: "
                 f"{len(slide.levels)}"
             )
-        if (
-            self.tile_size[0] > slide.level_dimensions(self.level)[0]
-            or self.tile_size[1] > slide.level_dimensions(self.level)[1]
-        ):
+        if not self._has_valid_tile_size(slide):
             raise TileSizeError(
                 f"Tile size {self.tile_size} is larger than slide size "
                 f"{slide.level_dimensions(self.level)} at level {self.level}"

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -5,11 +5,7 @@ from unittest.mock import call
 import numpy as np
 import pytest
 
-<<<<<<< 51d1465d3c1408c9857a54aaf216076e2a770bdb
-from histolab.exceptions import LevelError
-=======
 from histolab.exceptions import LevelError, TileSizeError
->>>>>>> Raise TileSizeError if the tile size is larger than the slide size
 from histolab.scorer import RandomScorer
 from histolab.slide import Slide
 from histolab.tile import Tile

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -412,10 +412,10 @@ class Describe_RandomTiler:
         image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
         slide_path = os.path.join(tmp_path_, "mywsi.png")
         slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
-        grid_tiler = RandomTiler((50, 52), n_tiles=10, level=0)
+        random_tiler = RandomTiler((50, 52), n_tiles=10, level=0)
 
         with pytest.raises(TileSizeError) as err:
-            grid_tiler.extract(slide)
+            random_tiler.extract(slide)
 
         assert isinstance(err.value, TileSizeError)
         assert (
@@ -1032,10 +1032,10 @@ class Describe_ScoreTiler:
         image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
         slide_path = os.path.join(tmp_path_, "mywsi.png")
         slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
-        grid_tiler = RandomTiler((50, 52), n_tiles=10, level=0)
+        score_tiler = ScoreTiler(None, (50, 52), 2, 0)
 
         with pytest.raises(TileSizeError) as err:
-            grid_tiler.extract(slide)
+            score_tiler.extract(slide)
 
         assert isinstance(err.value, TileSizeError)
         assert (

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -135,6 +135,22 @@ class Describe_RandomTiler:
         assert type(_filename) == str
         assert _filename == expected_filename
 
+    @pytest.mark.parametrize(
+        "tile_size, expected_result", [((512, 512), False), ((200, 200), True)]
+    )
+    def it_knows_if_it_has_valid_tile_size(self, tmpdir, tile_size, expected_result):
+        tmp_path_ = tmpdir.mkdir("myslide")
+        image = PILIMG.RGBA_COLOR_500X500_155_249_240
+        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+        slide_path = os.path.join(tmp_path_, "mywsi.png")
+        slide = Slide(slide_path, "processed")
+        random_tiler = RandomTiler(tile_size, 10, 0, 7)
+
+        result = random_tiler._has_valid_tile_size(slide)
+
+        assert type(result) == bool
+        assert result == expected_result
+
     def it_can_generate_random_coordinates(self, request, tmpdir):
         tmp_path_ = tmpdir.mkdir("myslide")
         image = PILIMG.RGBA_COLOR_500X500_155_249_240
@@ -383,6 +399,8 @@ class Describe_RandomTiler:
         _tile_filename.side_effect = [
             f"tile_{i}_level2_0-10-0-10.png" for i in range(2)
         ]
+        _has_valid_tile_size = method_mock(request, RandomTiler, "_has_valid_tile_size")
+        _has_valid_tile_size.return_value = True
         random_tiler = RandomTiler((10, 10), n_tiles=2, level=0)
 
         random_tiler.extract(slide)
@@ -397,6 +415,7 @@ class Describe_RandomTiler:
         assert os.path.exists(
             os.path.join(tmp_path_, "processed", "tiles", "tile_1_level2_0-10-0-10.png")
         )
+        _has_valid_tile_size.assert_called_once_with(random_tiler, slide)
 
     @pytest.mark.parametrize(
         "image, size",
@@ -406,12 +425,14 @@ class Describe_RandomTiler:
         ],
     )
     def but_it_raises_tilesizeerror_if_tilesize_larger_than_slidesize(
-        self, tmpdir, image, size
+        self, request, tmpdir, image, size
     ):
         tmp_path_ = tmpdir.mkdir("myslide")
         image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
         slide_path = os.path.join(tmp_path_, "mywsi.png")
         slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
+        _has_valid_tile_size = method_mock(request, RandomTiler, "_has_valid_tile_size")
+        _has_valid_tile_size.return_value = False
         random_tiler = RandomTiler((50, 52), n_tiles=10, level=0)
 
         with pytest.raises(TileSizeError) as err:
@@ -422,6 +443,7 @@ class Describe_RandomTiler:
             str(err.value)
             == f"Tile size (50, 52) is larger than slide size {size} at level 0"
         )
+        _has_valid_tile_size.assert_called_once_with(random_tiler, slide)
 
     # fixture components ---------------------------------------------
 
@@ -508,6 +530,22 @@ class Describe_GridTiler:
 
         assert type(_filename) == str
         assert _filename == expected_filename
+
+    @pytest.mark.parametrize(
+        "tile_size, expected_result", [((512, 512), False), ((200, 200), True)]
+    )
+    def it_knows_if_it_has_valid_tile_size(self, tmpdir, tile_size, expected_result):
+        tmp_path_ = tmpdir.mkdir("myslide")
+        image = PILIMG.RGBA_COLOR_500X500_155_249_240
+        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+        slide_path = os.path.join(tmp_path_, "mywsi.png")
+        slide = Slide(slide_path, "processed")
+        grid_tiler = GridTiler(tile_size, 0, True)
+
+        result = grid_tiler._has_valid_tile_size(slide)
+
+        assert type(result) == bool
+        assert result == expected_result
 
     @pytest.mark.parametrize(
         "check_tissue, expected_box",
@@ -743,6 +781,8 @@ class Describe_GridTiler:
             )
             for i in range(2)
         ]
+        _has_valid_tile_size = method_mock(request, GridTiler, "_has_valid_tile_size")
+        _has_valid_tile_size.return_value = True
         grid_tiler = GridTiler((10, 10), level=0)
 
         grid_tiler.extract(slide)
@@ -757,6 +797,7 @@ class Describe_GridTiler:
         assert os.path.exists(
             os.path.join(tmp_path_, "processed", "tiles", "tile_1_level2_0-10-0-10.png")
         )
+        _has_valid_tile_size.assert_called_once_with(grid_tiler, slide)
 
     @pytest.mark.parametrize(
         "image, size",
@@ -766,12 +807,14 @@ class Describe_GridTiler:
         ],
     )
     def but_it_raises_tilesizeerror_if_tilesize_larger_than_slidesize(
-        self, tmpdir, image, size
+        self, request, tmpdir, image, size
     ):
         tmp_path_ = tmpdir.mkdir("myslide")
         image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
         slide_path = os.path.join(tmp_path_, "mywsi.png")
         slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
+        _has_valid_tile_size = method_mock(request, GridTiler, "_has_valid_tile_size")
+        _has_valid_tile_size.return_value = False
         grid_tiler = GridTiler((50, 52), level=0)
 
         with pytest.raises(TileSizeError) as err:
@@ -782,6 +825,7 @@ class Describe_GridTiler:
             str(err.value)
             == f"Tile size (50, 52) is larger than slide size {size} at level 0"
         )
+        _has_valid_tile_size.assert_called_once_with(grid_tiler, slide)
 
 
 class Describe_ScoreTiler:
@@ -815,6 +859,22 @@ class Describe_ScoreTiler:
 
         assert type(n_tiles_) == int
         assert n_tiles_ == n_tiles
+
+    @pytest.mark.parametrize(
+        "tile_size, expected_result", [((512, 512), False), ((200, 200), True)]
+    )
+    def it_knows_if_it_has_valid_tile_size(self, tmpdir, tile_size, expected_result):
+        tmp_path_ = tmpdir.mkdir("myslide")
+        image = PILIMG.RGBA_COLOR_500X500_155_249_240
+        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+        slide_path = os.path.join(tmp_path_, "mywsi.png")
+        slide = Slide(slide_path, "processed")
+        score_tiler = ScoreTiler(RandomScorer(), tile_size, 2, 0)
+
+        result = score_tiler._has_valid_tile_size(slide)
+
+        assert type(result) == bool
+        assert result == expected_result
 
     def it_can_calculate_scores(self, request):
         slide = instance_mock(request, Slide)
@@ -997,6 +1057,8 @@ class Describe_ScoreTiler:
         ]
         _save_report = method_mock(request, ScoreTiler, "_save_report")
         random_scorer = RandomScorer()
+        _has_valid_tile_size = method_mock(request, ScoreTiler, "_has_valid_tile_size")
+        _has_valid_tile_size.return_value = True
         score_tiler = ScoreTiler(random_scorer, (10, 10), 2, 0)
 
         score_tiler.extract(slide)
@@ -1017,6 +1079,7 @@ class Describe_ScoreTiler:
             os.path.join(tmp_path_, "processed", "tiles", "tile_1_level2_0-10-0-10.png")
         )
         _save_report.assert_not_called()
+        _has_valid_tile_size.assert_called_once_with(score_tiler, slide)
 
     @pytest.mark.parametrize(
         "image, size",
@@ -1026,12 +1089,14 @@ class Describe_ScoreTiler:
         ],
     )
     def but_it_raises_tilesizeerror_if_tilesize_larger_than_slidesize(
-        self, tmpdir, image, size
+        self, request, tmpdir, image, size
     ):
         tmp_path_ = tmpdir.mkdir("myslide")
         image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
         slide_path = os.path.join(tmp_path_, "mywsi.png")
         slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
+        _has_valid_tile_size = method_mock(request, ScoreTiler, "_has_valid_tile_size")
+        _has_valid_tile_size.return_value = False
         score_tiler = ScoreTiler(None, (50, 52), 2, 0)
 
         with pytest.raises(TileSizeError) as err:
@@ -1042,6 +1107,7 @@ class Describe_ScoreTiler:
             str(err.value)
             == f"Tile size (50, 52) is larger than slide size {size} at level 0"
         )
+        _has_valid_tile_size.assert_called_once_with(score_tiler, slide)
 
     def it_can_save_report(self, request, tmpdir):
         tmp_path_ = tmpdir.mkdir("path")

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -383,7 +383,7 @@ class Describe_RandomTiler:
         _tile_filename.side_effect = [
             f"tile_{i}_level2_0-10-0-10.png" for i in range(2)
         ]
-        random_tiler = RandomTiler((10, 10), n_tiles=2, level=2)
+        random_tiler = RandomTiler((10, 10), n_tiles=2, level=0)
 
         random_tiler.extract(slide)
 
@@ -858,6 +858,20 @@ class Describe_ScoreTiler:
             == "No tiles have been generated. This could happen if `check_tissue=True`"
         )
 
+    def or_it_raises_levelerror_if_has_not_available_level_value(self, tmpdir):
+        tmp_path_ = tmpdir.mkdir("myslide")
+        image = PILIMG.RGB_RANDOM_COLOR_500X500
+        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+        slide_path = os.path.join(tmp_path_, "mywsi.png")
+        slide = Slide(slide_path, "processed")
+        score_tiler = ScoreTiler(None, (10, 10), 2, 3)
+
+        with pytest.raises(LevelError) as err:
+            score_tiler.extract(slide)
+
+        assert isinstance(err.value, LevelError)
+        assert str(err.value) == "Level 3 not available. Number of available levels: 1"
+
     def it_can_scale_scores(self):
         coords = [CP(0, 10 * i, 0, 10) for i in range(3)]
         scores = [0.3, 0.4, 0.7]
@@ -938,8 +952,12 @@ class Describe_ScoreTiler:
         _scores.assert_called_once_with(score_tiler, slide)
         assert highest_score_tiles == expected_value
 
-    def but_it_raises_error_with_negative_n_tiles_value(self, request):
-        slide = instance_mock(request, Slide)
+    def but_it_raises_error_with_negative_n_tiles_value(self, request, tmpdir):
+        tmp_path_ = tmpdir.mkdir("myslide")
+        image = PILIMG.RGBA_COLOR_500X500_155_249_240
+        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+        slide_path = os.path.join(tmp_path_, "mywsi.png")
+        slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
         _scores = method_mock(request, ScoreTiler, "_scores")
         coords = CP(0, 10, 0, 10)
         _scores.return_value = [
@@ -979,13 +997,13 @@ class Describe_ScoreTiler:
         ]
         _save_report = method_mock(request, ScoreTiler, "_save_report")
         random_scorer = RandomScorer()
-        score_tiler = ScoreTiler(random_scorer, (10, 10), 2, 2)
+        score_tiler = ScoreTiler(random_scorer, (10, 10), 2, 0)
 
         score_tiler.extract(slide)
 
         assert _extract_tile.call_args_list == [
-            call(slide, coords, 2),
-            call(slide, coords, 2),
+            call(slide, coords, 0),
+            call(slide, coords, 0),
         ]
         _highest_score_tiles.assert_called_once_with(score_tiler, slide)
         assert _tile_filename.call_args_list == [
@@ -1073,13 +1091,13 @@ class Describe_ScoreTiler:
         ]
         _save_report = method_mock(request, ScoreTiler, "_save_report", autospec=False)
         random_scorer = RandomScorer()
-        score_tiler = ScoreTiler(random_scorer, (10, 10), 2, 2)
+        score_tiler = ScoreTiler(random_scorer, (10, 10), 2, 0)
 
         score_tiler.extract(slide, "report.csv")
 
         assert _extract_tile.call_args_list == [
-            call(slide, coords, 2),
-            call(slide, coords, 2),
+            call(slide, coords, 0),
+            call(slide, coords, 0),
         ]
         _highest_score_tiles.assert_called_once_with(score_tiler, slide)
         assert _tile_filename.call_args_list == [

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -5,7 +5,11 @@ from unittest.mock import call
 import numpy as np
 import pytest
 
+<<<<<<< 51d1465d3c1408c9857a54aaf216076e2a770bdb
 from histolab.exceptions import LevelError
+=======
+from histolab.exceptions import LevelError, TileSizeError
+>>>>>>> Raise TileSizeError if the tile size is larger than the slide size
 from histolab.scorer import RandomScorer
 from histolab.slide import Slide
 from histolab.tile import Tile
@@ -394,6 +398,31 @@ class Describe_RandomTiler:
             os.path.join(tmp_path_, "processed", "tiles", "tile_1_level2_0-10-0-10.png")
         )
 
+    @pytest.mark.parametrize(
+        "image, size",
+        [
+            (PILIMG.RGBA_COLOR_50X50_155_0_0, (50, 50)),
+            (PILIMG.RGBA_COLOR_49X51_155_0_0, (49, 51)),
+        ],
+    )
+    def but_it_raises_tilesizeerror_if_tilesize_larger_than_slidesize(
+        self, tmpdir, image, size
+    ):
+        tmp_path_ = tmpdir.mkdir("myslide")
+        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+        slide_path = os.path.join(tmp_path_, "mywsi.png")
+        slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
+        grid_tiler = RandomTiler((50, 52), n_tiles=10, level=0)
+
+        with pytest.raises(TileSizeError) as err:
+            grid_tiler.extract(slide)
+
+        assert isinstance(err.value, TileSizeError)
+        assert (
+            str(err.value)
+            == f"Tile size (50, 52) is larger than slide size {size} at level 0"
+        )
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture
@@ -729,6 +758,31 @@ class Describe_GridTiler:
             os.path.join(tmp_path_, "processed", "tiles", "tile_1_level2_0-10-0-10.png")
         )
 
+    @pytest.mark.parametrize(
+        "image, size",
+        [
+            (PILIMG.RGBA_COLOR_50X50_155_0_0, (50, 50)),
+            (PILIMG.RGBA_COLOR_49X51_155_0_0, (49, 51)),
+        ],
+    )
+    def but_it_raises_tilesizeerror_if_tilesize_larger_than_slidesize(
+        self, tmpdir, image, size
+    ):
+        tmp_path_ = tmpdir.mkdir("myslide")
+        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+        slide_path = os.path.join(tmp_path_, "mywsi.png")
+        slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
+        grid_tiler = GridTiler((50, 52), level=0)
+
+        with pytest.raises(TileSizeError) as err:
+            grid_tiler.extract(slide)
+
+        assert isinstance(err.value, TileSizeError)
+        assert (
+            str(err.value)
+            == f"Tile size (50, 52) is larger than slide size {size} at level 0"
+        )
+
 
 class Describe_ScoreTiler:
     def it_constructs_from_args(self, request):
@@ -945,6 +999,31 @@ class Describe_ScoreTiler:
             os.path.join(tmp_path_, "processed", "tiles", "tile_1_level2_0-10-0-10.png")
         )
         _save_report.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "image, size",
+        [
+            (PILIMG.RGBA_COLOR_50X50_155_0_0, (50, 50)),
+            (PILIMG.RGBA_COLOR_49X51_155_0_0, (49, 51)),
+        ],
+    )
+    def but_it_raises_tilesizeerror_if_tilesize_larger_than_slidesize(
+        self, tmpdir, image, size
+    ):
+        tmp_path_ = tmpdir.mkdir("myslide")
+        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+        slide_path = os.path.join(tmp_path_, "mywsi.png")
+        slide = Slide(slide_path, os.path.join(tmp_path_, "processed"))
+        grid_tiler = RandomTiler((50, 52), n_tiles=10, level=0)
+
+        with pytest.raises(TileSizeError) as err:
+            grid_tiler.extract(slide)
+
+        assert isinstance(err.value, TileSizeError)
+        assert (
+            str(err.value)
+            == f"Tile size (50, 52) is larger than slide size {size} at level 0"
+        )
 
     def it_can_save_report(self, request, tmpdir):
         tmp_path_ = tmpdir.mkdir("path")

--- a/tests/unitutil.py
+++ b/tests/unitutil.py
@@ -5,14 +5,14 @@
 import os
 import sys
 
-import pytest
 import numpy as np
+import pytest
 from PIL import Image
+
+from histolab import data
 
 from unittest.mock import ANY, call  # noqa # isort:skip
 from unittest.mock import create_autospec, patch, PropertyMock  # isort:skip
-
-from histolab import data
 
 
 def dict_list_eq(l1, l2):
@@ -108,7 +108,10 @@ class PILImageMock:
     RGBA_COLOR_500X500_155_249_240 = Image.new(
         "RGBA", size=(500, 500), color=(155, 249, 240)
     )
+
     RGBA_COLOR_50X50_155_0_0 = Image.new("RGBA", size=(50, 50), color=(155, 0, 0))
+
+    RGBA_COLOR_49X51_155_0_0 = Image.new("RGBA", size=(49, 51), color=(155, 0, 0))
 
     RGB_RANDOM_COLOR_500X500 = Image.fromarray(
         (np.random.rand(500, 500, 3) * 255).astype("uint8")


### PR DESCRIPTION
fixes #192

AND check in `Tiler.extract()` if the level is available 