### PR TITLE
groom unit tests wrapping base slide creation in unitutil

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change. 
+When contributing to this repository, please first discuss the change you wish to make via issue or any other 
+method with the owners of this repository before making a change. 
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
@@ -15,8 +15,9 @@ style.
 - Bug fixes also generally require unit tests, because the presence of bugs usually indicates insufficient test 
   coverage.
 - Keep API compatibility in mind when you change code in Histolab core.
-- Tests coverage cannot decrease from the current %.
+- Tests coverage cannot decrease from the current % (current coverage 100%).
 - Do not push integration tests without unit tests.
+- Pay attention to the CI required checks
 
 ## Contribution Workflow
 
@@ -87,7 +88,7 @@ Additional git and GitHub resources:
 
 Before starting contributing to Histolab, test that your local environment is up and running. Here some steps:
 
-- Create a python 3.6 - 3.7 `virtualenv`
+- Create a python 3.6, 3.7 or 3.8 `virtualenv`
 - Activate the env and in the project root run:
   
   `pip install -e .[testing]`
@@ -100,7 +101,11 @@ Before starting contributing to Histolab, test that your local environment is up
 
 - Run the tests
  
-   `pytest`
+   `pytest` or if you wanna skip the benchmarks `pytest --ignore=tests/benchmarks`
+
+- Run tests in parallel (requires `pytest-xdist`)
+
+   `pytest --ignore=tests/benchmarks -n auto`
 
 ## Code of Conduct
 

--- a/tests/unit/test_slide.py
+++ b/tests/unit/test_slide.py
@@ -447,7 +447,7 @@ class Describe_Slide:
         not on_ci() or is_win32(), reason="Only run on CIs; hangs on Windows CIs"
     )
     def it_can_show_its_thumbnail(self, tmpdir):
-        slide = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
 
         slide.save_thumbnail()
 

--- a/tests/unit/test_slide.py
+++ b/tests/unit/test_slide.py
@@ -21,6 +21,7 @@ from histolab.util import regions_from_binary_mask
 from ..unitutil import (
     ANY,
     PILIMG,
+    base_test_slide,
     class_mock,
     dict_list_eq,
     function_mock,
@@ -201,11 +202,7 @@ class Describe_Slide:
         assert thumbnail_path == expected_value
 
     def it_knows_its_dimensions(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
 
         slide_dims = slide.dimensions
 
@@ -240,11 +237,7 @@ class Describe_Slide:
         assert str(err.value) == "division by zero"
 
     def it_knows_its_resampled_array(self, tmpdir, resampled_dims_):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         resampled_dims_.return_value = (100, 200, 300, 400)
 
         resampled_array = slide.resampled_array(scale_factor=32)
@@ -253,22 +246,14 @@ class Describe_Slide:
         assert resampled_array.shape == (400, 300, 3)
 
     def it_knows_its_thumbnail_size(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
 
         thumb_size = slide._thumbnail_size
 
         assert thumb_size == (500, 500)
 
     def it_creates_a_correct_slide_object(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_50X50_155_0_0
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_50X50_155_0_0)
 
         _wsi = slide._wsi
 
@@ -295,11 +280,7 @@ class Describe_Slide:
         )
 
     def it_can_resample_itself(self, tmpdir, resampled_dims_):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         resampled_dims_.return_value = (100, 200, 300, 400)
 
         _resample = slide._resample(32)
@@ -324,11 +305,7 @@ class Describe_Slide:
         assert _resample[0].mode == "RGB"
 
     def it_resamples_with_the_correct_scale_factor(self, tmpdir, resampled_dims_):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         resampled_dims_.return_value = (500, 500, 15, 15)
 
         _resample = slide._resample(32)
@@ -423,11 +400,7 @@ class Describe_Slide:
         RemoveSmallHoles_,
         RemoveSmallObjects_,
     ):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         regions = [Region(index=0, area=33, bbox=(0, 0, 2, 2), center=(0.5, 0.5))]
         main_tissue_areas_mask_filters_ = property_mock(
             request, _SlideFiltersComposition, "tissue_mask_filters"
@@ -474,11 +447,7 @@ class Describe_Slide:
         not on_ci() or is_win32(), reason="Only run on CIs; hangs on Windows CIs"
     )
     def it_can_show_its_thumbnail(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
 
         slide.save_thumbnail()
 
@@ -500,11 +469,7 @@ class Describe_Slide:
         "level, expected_value", ((0, (500, 500)), (-1, (500, 500)))
     )
     def it_knows_its_level_dimensions(self, level, expected_value, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
 
         level_dimensions = slide.level_dimensions(level=level)
 
@@ -512,11 +477,8 @@ class Describe_Slide:
 
     @pytest.mark.parametrize("level", (3, -3))
     def but_it_raises_expection_when_level_does_not_exist(self, level, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
+
         with pytest.raises(LevelError) as err:
             slide.level_dimensions(level=level)
 
@@ -535,11 +497,7 @@ class Describe_Slide:
         ),
     )
     def it_knows_if_coords_are_valid(self, coords, expected_result, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
 
         _are_valid = slide._has_valid_coords(coords)
 
@@ -547,11 +505,7 @@ class Describe_Slide:
         assert _are_valid == expected_result
 
     def it_knows_its_levels(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
 
         levels = slide.levels
 
@@ -575,11 +529,7 @@ class Describe_Slide:
 
     def but_it_raises_a_level_error_when_it_cannot_be_mapped(self, tmpdir, levels_prop):
         levels_prop.return_value = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGB_RANDOM_COLOR_500X500
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGB_RANDOM_COLOR_500X500)
 
         with pytest.raises(LevelError) as err:
             slide._remap_level(-10)

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -15,6 +15,7 @@ from histolab.types import CP
 from ..unitutil import (
     ANY,
     PILIMG,
+    base_test_slide,
     NpArrayMock,
     function_mock,
     initializer_mock,
@@ -45,11 +46,7 @@ class Describe_RandomTiler:
         assert str(err.value) == "Tile size must be greater than 0 ((512, -1))"
 
     def or_it_has_not_available_level_value(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGB_RANDOM_COLOR_500X500
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGB_RANDOM_COLOR_500X500)
         random_tiler = RandomTiler((128, 128), 10, 3)
 
         with pytest.raises(LevelError) as err:
@@ -70,11 +67,7 @@ class Describe_RandomTiler:
         )
 
     def or_it_has_wrong_seed(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGB_RANDOM_COLOR_500X500
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGB_RANDOM_COLOR_500X500)
         random_tiler = RandomTiler((128, 128), 10, 0, seed=-1)
 
         with pytest.raises(ValueError) as err:
@@ -129,11 +122,7 @@ class Describe_RandomTiler:
         "tile_size, expected_result", [((512, 512), False), ((200, 200), True)]
     )
     def it_knows_if_it_has_valid_tile_size(self, tmpdir, tile_size, expected_result):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         random_tiler = RandomTiler(tile_size, 10, 0, 7)
 
         result = random_tiler._has_valid_tile_size(slide)
@@ -142,11 +131,7 @@ class Describe_RandomTiler:
         assert result == expected_result
 
     def it_can_generate_random_coordinates(self, request, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _box_mask_thumb = method_mock(request, RandomTiler, "box_mask")
         _box_mask_thumb.return_value = NpArrayMock.ONES_500X500_BOOL
         _tile_size = property_mock(request, RandomTiler, "tile_size")
@@ -176,11 +161,7 @@ class Describe_RandomTiler:
         ),
     )
     def it_knows_its_box_mask(self, request, tmpdir, check_tissue, expected_box):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _biggest_tissue_box_mask = property_mock(
             request, Slide, "biggest_tissue_box_mask"
         )
@@ -230,11 +211,7 @@ class Describe_RandomTiler:
         expected_value,
         _random_tile_coordinates,
     ):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _extract_tile = method_mock(request, Slide, "extract_tile")
         _has_enough_tissue = method_mock(request, Tile, "has_enough_tissue")
         _has_enough_tissue.side_effect = has_enough_tissue * (max_iter // 2)
@@ -264,11 +241,7 @@ class Describe_RandomTiler:
         tmpdir,
         _random_tile_coordinates,
     ):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _extract_tile = method_mock(request, Slide, "extract_tile")
         _has_enough_tissue = method_mock(request, Tile, "has_enough_tissue")
         _has_enough_tissue.side_effect = [False, False] * 5
@@ -332,11 +305,7 @@ class Describe_RandomTiler:
         expected_value,
         _random_tile_coordinates,
     ):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _extract_tile = method_mock(request, Slide, "extract_tile")
         _has_enough_tissue = method_mock(request, Tile, "has_enough_tissue")
         _has_enough_tissue.side_effect = has_enough_tissue * (max_iter // 2)
@@ -364,11 +333,7 @@ class Describe_RandomTiler:
     ):
         random_tiler = RandomTiler((10, 10), 1, level=0, max_iter=1, check_tissue=False)
         _random_tile_coordinates.side_effect = [CP(-1, -1, -1, -1), CP(0, 10, 0, 10)]
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
 
         generated_tiles = list(random_tiler._tiles_generator(slide))
 
@@ -461,11 +426,8 @@ class Describe_GridTiler:
         assert str(err.value) == "Tile size must be greater than 0 ((512, -1))"
 
     def or_it_has_not_available_level_value(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGB_RANDOM_COLOR_500X500
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGB_RANDOM_COLOR_500X500)
+
         grid_tiler = GridTiler((128, 128), 3)
 
         with pytest.raises(LevelError) as err:
@@ -519,11 +481,7 @@ class Describe_GridTiler:
         "tile_size, expected_result", [((512, 512), False), ((200, 200), True)]
     )
     def it_knows_if_it_has_valid_tile_size(self, tmpdir, tile_size, expected_result):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         grid_tiler = GridTiler(tile_size, 0, True)
 
         result = grid_tiler._has_valid_tile_size(slide)
@@ -539,11 +497,7 @@ class Describe_GridTiler:
         ),
     )
     def it_knows_its_box_mask(self, request, tmpdir, check_tissue, expected_box):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _biggest_tissue_box_mask = property_mock(
             request, Slide, "biggest_tissue_box_mask"
         )
@@ -626,11 +580,7 @@ class Describe_GridTiler:
         has_enough_tissue,
         expected_n_tiles,
     ):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _extract_tile = method_mock(request, Slide, "extract_tile")
         _has_enough_tissue = method_mock(request, Tile, "has_enough_tissue")
         _has_enough_tissue.side_effect = has_enough_tissue
@@ -679,11 +629,7 @@ class Describe_GridTiler:
         has_enough_tissue,
         expected_n_tiles,
     ):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _extract_tile = method_mock(request, Slide, "extract_tile")
         _has_enough_tissue = method_mock(request, Tile, "has_enough_tissue")
         _has_enough_tissue.side_effect = has_enough_tissue
@@ -707,11 +653,7 @@ class Describe_GridTiler:
             assert tile[0] == tiles[i]
 
     def but_with_wrong_coordinates(self, request, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         _has_enough_tissue = method_mock(request, Tile, "has_enough_tissue")
         _has_enough_tissue.return_value = False
         _grid_coordinates_generator = method_mock(
@@ -732,11 +674,7 @@ class Describe_GridTiler:
         assert generated_tiles[0][1] == coords2
 
     def and_doesnt_raise_error_with_wrong_coordinates(self, request, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         coords = CP(5800, 6000, 5800, 6000)
         _grid_coordinates_generator = method_mock(
             request, GridTiler, "_grid_coordinates_generator"
@@ -848,11 +786,7 @@ class Describe_ScoreTiler:
         "tile_size, expected_result", [((512, 512), False), ((200, 200), True)]
     )
     def it_knows_if_it_has_valid_tile_size(self, tmpdir, tile_size, expected_result):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGBA_COLOR_500X500_155_249_240
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
         score_tiler = ScoreTiler(RandomScorer(), tile_size, 2, 0)
 
         result = score_tiler._has_valid_tile_size(slide)
@@ -903,11 +837,7 @@ class Describe_ScoreTiler:
         )
 
     def or_it_raises_levelerror_if_has_not_available_level_value(self, tmpdir):
-        tmp_path_ = tmpdir.mkdir("myslide")
-        image = PILIMG.RGB_RANDOM_COLOR_500X500
-        image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
-        slide_path = os.path.join(tmp_path_, "mywsi.png")
-        slide = Slide(slide_path, "processed")
+        slide, _ = base_test_slide(tmpdir, PILIMG.RGB_RANDOM_COLOR_500X500)
         score_tiler = ScoreTiler(None, (10, 10), 2, 3)
 
         with pytest.raises(LevelError) as err:

--- a/tests/unitutil.py
+++ b/tests/unitutil.py
@@ -10,9 +10,18 @@ import pytest
 from PIL import Image
 
 from histolab import data
+from histolab.slide import Slide
 
 from unittest.mock import ANY, call  # noqa # isort:skip
 from unittest.mock import create_autospec, patch, PropertyMock  # isort:skip
+
+
+def base_test_slide(tmpdir, image):
+    tmp_path_ = tmpdir.mkdir("myslide")
+    image.save(os.path.join(tmp_path_, "mywsi.png"), "PNG")
+    slide_path = os.path.join(tmp_path_, "mywsi.png")
+    slide = Slide(slide_path, "processed")
+    return slide, tmp_path_
 
 
 def dict_list_eq(l1, l2):


### PR DESCRIPTION
This PR simply groom test_slide and test_tiler (unit) avoiding code fragments duplicates