### PR TITLE
Use logger object instead of logging module when logging tiler updates

### DIFF
--- a/src/histolab/tiler.py
+++ b/src/histolab/tiler.py
@@ -275,8 +275,8 @@ class GridTiler(Tiler):
             tile_filename = self._tile_filename(tile_wsi_coords, tiles_counter)
             full_tile_path = os.path.join(slide.processed_path, tile_filename)
             tile.save(full_tile_path)
-            logging.info(f"\t Tile {tiles_counter} saved: {tile_filename}")
-        logging.info(f"{tiles_counter} Grid Tiles have been saved.")
+            logger.info(f"\t Tile {tiles_counter} saved: {tile_filename}")
+        logger.info(f"{tiles_counter} Grid Tiles have been saved.")
 
     @property
     def tile_size(self) -> Tuple[int, int]:
@@ -526,8 +526,8 @@ class RandomTiler(Tiler):
             tile_filename = self._tile_filename(tile_wsi_coords, tiles_counter)
             full_tile_path = os.path.join(slide.processed_path, tile_filename)
             tile.save(full_tile_path)
-            logging.info(f"\t Tile {tiles_counter} saved: {tile_filename}")
-        logging.info(f"{tiles_counter+1} Random Tiles have been saved.")
+            logger.info(f"\t Tile {tiles_counter} saved: {tile_filename}")
+        logger.info(f"{tiles_counter+1} Random Tiles have been saved.")
 
     @property
     def max_iter(self) -> int:
@@ -751,7 +751,7 @@ class ScoreTiler(GridTiler):
             tile_filename = self._tile_filename(tile_wsi_coords, tiles_counter)
             tile.save(os.path.join(slide.processed_path, tile_filename))
             filenames.append(tile_filename)
-            logging.info(
+            logger.info(
                 f"\t Tile {tiles_counter} - score: {score} saved: {tile_filename}"
             )
 
@@ -760,7 +760,7 @@ class ScoreTiler(GridTiler):
                 report_path, highest_score_tiles, highest_scaled_score_tiles, filenames
             )
 
-        logging.info(f"{tiles_counter+1} Grid Tiles have been saved.")
+        logger.info(f"{tiles_counter+1} Grid Tiles have been saved.")
 
     # ------- implementation helpers -------
 

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -351,9 +351,9 @@ class Describe_RandomTiler:
             random_tiler.extract(slide, binary_mask)
 
         assert re.sub(r":+\d{3}", "", caplog.text).splitlines() == [
-            "INFO     root:tiler.py \t Tile 0 saved: tile_0_level2_0-10-0-10.png",
-            "INFO     root:tiler.py \t Tile 1 saved: tile_1_level2_0-10-0-10.png",
-            "INFO     root:tiler.py 2 Random Tiles have been saved.",
+            "INFO     tiler:tiler.py \t Tile 0 saved: tile_0_level2_0-10-0-10.png",
+            "INFO     tiler:tiler.py \t Tile 1 saved: tile_1_level2_0-10-0-10.png",
+            "INFO     tiler:tiler.py 2 Random Tiles have been saved.",
         ]
         assert _tile_filename.call_args_list == [
             call(random_tiler, coords, 0),


### PR DESCRIPTION
This is a simple bug fix. Currently the `tile` module logger uses the logging module instead of the logger object, which results in non-specific logger messages from the **root**:
``INFO:root:	 Tile 0 - score: 0.5016428618605987 saved: vlres_tiles/tile_0_level3_38914-40962-40962-43010.png``

Instead of specific messages that bear the **tiler** prefix, i.e.:
``INFO:tiler:	 Tile 0 - score: 0.5016428618605987 saved: vlres_tiles/tile_0_level3_38914-40962-40962-43010.png``

When this is part of a large codebase, it is desirable to know where the log message is coming from. This fixes this issue.
