### PR TITLE
Allow slide name to contain dot

### DIFF
--- a/src/histolab/slide.py
+++ b/src/histolab/slide.py
@@ -207,7 +207,7 @@ class Slide:
         name : str
         """
         bname = ntpath.basename(self._path)
-        return bname[:bname.rfind(".")]
+        return bname[: bname.rfind(".")]
 
     @lazyproperty
     def processed_path(self) -> str:

--- a/src/histolab/slide.py
+++ b/src/histolab/slide.py
@@ -206,7 +206,8 @@ class Slide:
         -------
         name : str
         """
-        return ntpath.basename(self._path).split(".")[0]
+        bname = ntpath.basename(self._path)
+        return bname[:bname.rfind(".")]
 
     @lazyproperty
     def processed_path(self) -> str:

--- a/tests/unit/test_slide.py
+++ b/tests/unit/test_slide.py
@@ -89,7 +89,8 @@ class Describe_Slide:
         "slide_path, expected_value",
         (
             ("/foo/bar/myslide.svs", "myslide"),
-            ("/foo/myslide.svs", "myslide")("/foo/name.has.dot.svs", "name.has.dot"),
+            ("/foo/myslide.svs", "myslide"),
+            ("/foo/name.has.dot.svs", "name.has.dot"),
         ),
     )
     def it_knows_its_name(self, slide_path, expected_value):

--- a/tests/unit/test_slide.py
+++ b/tests/unit/test_slide.py
@@ -87,8 +87,10 @@ class Describe_Slide:
 
     @pytest.mark.parametrize(
         "slide_path, expected_value",
-        (("/foo/bar/myslide.svs", "myslide"), ("/foo/myslide.svs", "myslide")
-        ("/foo/name.has.dot.svs", "name.has.dot")),
+        (
+            ("/foo/bar/myslide.svs", "myslide"),
+            ("/foo/myslide.svs", "myslide")("/foo/name.has.dot.svs", "name.has.dot"),
+        ),
     )
     def it_knows_its_name(self, slide_path, expected_value):
         slide = Slide(slide_path, "processed/")

--- a/tests/unit/test_slide.py
+++ b/tests/unit/test_slide.py
@@ -87,7 +87,8 @@ class Describe_Slide:
 
     @pytest.mark.parametrize(
         "slide_path, expected_value",
-        (("/foo/bar/myslide.svs", "myslide"), ("/foo/myslide.svs", "myslide")),
+        (("/foo/bar/myslide.svs", "myslide"), ("/foo/myslide.svs", "myslide")
+        ("/foo/name.has.dot.svs", "name.has.dot")),
     )
     def it_knows_its_name(self, slide_path, expected_value):
         slide = Slide(slide_path, "processed/")


### PR DESCRIPTION
If a slide name contains one or more dots in its middle, other than the extension, make sure to retain that in the ``self.name`` property of ``Slide``.