### PR TITLE
Handle edge case for _are_coordinates_within_extraction_mask 

### DIFF
--- a/src/histolab/tiler.py
+++ b/src/histolab/tiler.py
@@ -333,7 +333,7 @@ class GridTiler(Tiler):
         tile_area = np.count_nonzero(tile_thumb_mask)
         tile_in_binary_mask_area = np.count_nonzero(tile_in_binary_mask)
 
-        return (
+        return tile_area > 0 and (
             tile_in_binary_mask_area / tile_area
             > COORDS_WITHIN_EXTRACTION_MASK_THRESHOLD
         )

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -758,6 +758,7 @@ class Describe_GridTiler:
     @pytest.mark.parametrize(
         "tile_coords, expected_result",
         [
+            (CP(2, 6, 6, 7), False),  # bad edge coordinates from np.ceil/floor
             (CP(0, 0, 2, 2), False),  # completely outside of region
             (CP(0, 0, 8, 8), False),  # only 205
             (CP(2, 3, 6, 6), True),  # 85% in

--- a/tests/unit/test_tiler.py
+++ b/tests/unit/test_tiler.py
@@ -758,7 +758,7 @@ class Describe_GridTiler:
     @pytest.mark.parametrize(
         "tile_coords, expected_result",
         [
-            (CP(2, 6, 6, 7), False),  # bad edge coordinates from np.ceil/floor
+            (CP(2, 6, 6, 6), False),  # bad edge coordinates from np.ceil/floor
             (CP(0, 0, 2, 2), False),  # completely outside of region
             (CP(0, 0, 8, 8), False),  # only 205
             (CP(2, 3, 6, 6), True),  # 85% in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

Handle edge case for ``_are_coordinates_within_extraction_mask`` where tile coordinates are off by 1 or 2 pixels due to conversion of floats to ints and usage of np.ceil or np.floor.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Only if the tile coordinates are valid does the function return True. Explicitly checking if ``tile_area`` > 0 avoids ``DivisionByZeroError``. This edge case is rare, but I've encountered it in some of the slides I'm working with.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/histolab/histolab/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
