### PR TITLE
Pin pooch and be compliant with future versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
           python -m pip install -e .[testing]
           python -m pip install flake8==3.8.4
           python -m pip install black==21.6b0
-          python -m pip install pooch
+          python -m pip install pooch==1.4.0
 
       - name: Black Code Style Format Check
         id: black

--- a/src/histolab/data/__init__.py
+++ b/src/histolab/data/__init__.py
@@ -19,7 +19,7 @@ legacy_data_dir = os.path.abspath(os.path.dirname(__file__))
 histolab_distribution_dir = os.path.join(legacy_data_dir, "..")
 
 try:
-    from pooch.utils import file_hash
+    from pooch import file_hash
 except ModuleNotFoundError:
     # Function taken from
     # https://github.com/fatiando/pooch/blob/master/pooch/utils.py

--- a/tests/unit/data/test_data.py
+++ b/tests/unit/data/test_data.py
@@ -114,8 +114,8 @@ def test_pooch_missing(monkeypatch):
     from histolab import data
 
     fakesysmodules = copy.copy(sys.modules)
-    fakesysmodules["pooch.utils"] = None
-    monkeypatch.delitem(sys.modules, "pooch.utils")
+    fakesysmodules["pooch"] = None
+    monkeypatch.delitem(sys.modules, "pooch")
     monkeypatch.setattr("sys.modules", fakesysmodules)
     file = SVS.CMU_1_SMALL_REGION
     reload(data)
@@ -129,8 +129,8 @@ def test_file_hash_with_wrong_algorithm(monkeypatch):
     from histolab import data
 
     fakesysmodules = copy.copy(sys.modules)
-    fakesysmodules["pooch.utils"] = None
-    monkeypatch.delitem(sys.modules, "pooch.utils")
+    fakesysmodules["pooch"] = None
+    monkeypatch.delitem(sys.modules, "pooch")
     monkeypatch.setattr("sys.modules", fakesysmodules)
     file = SVS.CMU_1_SMALL_REGION
     reload(data)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
With pooch 1.5.0 the import with `from pooch.utils import file_hash` doesn't work anymore, even though they claim to not change the public API (https://github.com/fatiando/pooch/pull/244).

However, we need to stay with pooch 1.4.0 to be compatible with skimage == 1.17.2 (we need to remember to upgrade the pin when we merge https://github.com/histolab/histolab/pull/196).

Anyway I changed the code to be compliant with both versions.


## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes: 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/histolab/histolab/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
