### PR TITLE
Allow custom filters in TissueMask

### DIFF
--- a/histolab/masks.py
+++ b/histolab/masks.py
@@ -222,5 +222,4 @@ class TissueMask(BinaryMask):
         if len(self.custom_filters) > 0:
             custom_filters = FiltersComposition(Compose, *self.custom_filters)
             return tile.calculate_tissue_mask(custom_filters)
-        else:
-            return tile.tissue_mask
+        return tile.tissue_mask

--- a/histolab/tile.py
+++ b/histolab/tile.py
@@ -170,6 +170,26 @@ class Tile:
     def tissue_mask(self) -> np.ndarray:
         """Binary mask representing the tissue in the tile.
 
+        It is calculated given a composition of suitable filters.
+        If a non-default composition is required, consider ``calculate_tissue_mask``.
+
+        Returns
+        -------
+        np.ndarray
+            Binary mask representing the tissue in the tile.
+        """
+        return self.calculate_tissue_mask(FiltersComposition(Tile))
+
+    def calculate_tissue_mask(
+        self, filter_composition: FiltersComposition
+    ) -> np.ndarray:
+        """Calculate the binary mask representing the tissue in the tile.
+
+        Parameters
+        ---------
+        filter_composition: FiltersComposition
+            FiltersComposition used to calculate the mask.
+
         Returns
         -------
         np.ndarray
@@ -200,7 +220,7 @@ class Tile:
         tile_border = PIL.Image.fromarray(np_tile_border)
 
         # apply filters on tile with border
-        filters = FiltersComposition(Tile).tissue_mask_filters
+        filters = filter_composition.tissue_mask_filters
         mask_border = filters(tile_border)
 
         # remove border

--- a/tests/unit/test_masks.py
+++ b/tests/unit/test_masks.py
@@ -180,10 +180,13 @@ class DescribeTissueMask:
     def it_knows_its_mask_tile_and_supports_custom_filters(self, request):
         tile = Tile(PILIMG.RGBA_COLOR_500X500_155_249_240, None, None)
         custom_filters = [CustomFilterForTest()]
-        expected_mask = [
-            [True, True],
-            [False, True],
-        ]
+        expected_mask = np.asarray(
+            [
+                [True, True],
+                [False, True],
+            ],
+            dtype=bool,
+        )
         calculate_tissue_mask_call = method_mock(request, Tile, "calculate_tissue_mask")
         calculate_tissue_mask_call.return_value = expected_mask
 
@@ -203,7 +206,7 @@ class DescribeTissueMask:
             custom_filters
         )
 
-        assert binary_mask == expected_mask
+        np.testing.assert_array_equal(binary_mask, expected_mask)
 
 
 # fixture components ---------------------------------------------


### PR DESCRIPTION
## Description

This small patch allows a custom "pipeline" of image filters within the TissueMask to optimize for specific demands regarding tissue. The default behavior is not changed.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes: #375 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/histolab/histolab/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
