### PR TITLE
Fix type hints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,11 @@ jobs:
         run: |
           flake8 . --config=setup.cfg --count --statistics
 
+      - name: mypy
+        id: black
+        run: |
+          mypy histolab .
+
       - name: Check Vulnerabilities with Bandit
         id: bandit
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ Pipfile
 .mypy_cache/
 .dmypy.json
 dmypy.json
+report/
 
 # Pyre type checker
 .pyre/

--- a/histolab/filters/image_filters.py
+++ b/histolab/filters/image_filters.py
@@ -19,32 +19,31 @@
 object. Additionally, some of the image filters in histolab leverage functions and
 utilities by scikit-image. Image filters are divided into sub-categories, depending on
 their behaviour and output type.
- """
+"""
 
 import operator
 from abc import abstractmethod
 from typing import Any, Callable, List, Union
 
 import numpy as np
-import PIL
+from PIL import  ImageOps
+import PIL.Image
+from typing_extensions import Protocol, runtime_checkable
 
 from .. import util
 from . import image_filters_functional as F
 
-try:
-    from typing import Protocol, runtime_checkable
-except ImportError:
-    from typing_extensions import Protocol, runtime_checkable
+ImageOrNPArray = Union[PIL.Image.Image, np.ndarray]
 
 
+# TODO: should we remove this and only keep ImageFilter?
+# TODO: does it make sense to pass an np.ndarray as input?
 @runtime_checkable
 class Filter(Protocol):
     """Filter protocol"""
 
     @abstractmethod
-    def __call__(
-        self, img: Union[PIL.Image.Image, np.ndarray]
-    ) -> Union[PIL.Image.Image, np.ndarray]:
+    def __call__(self, img: ImageOrNPArray) -> ImageOrNPArray:
         pass  # pragma: no cover
 
     def __repr__(self) -> str:
@@ -56,7 +55,7 @@ class ImageFilter(Filter, Protocol):
     """Image filter protocol"""
 
     @abstractmethod
-    def __call__(self, img: PIL.Image.Image) -> Union[PIL.Image.Image, np.ndarray]:
+    def __call__(self, img: ImageOrNPArray) -> ImageOrNPArray:
         pass  # pragma: no cover
 
 
@@ -72,7 +71,7 @@ class Compose(ImageFilter):
     def __init__(self, filters: List[Filter]) -> None:
         self.filters = filters
 
-    def __call__(self, img: PIL.Image.Image) -> Union[PIL.Image.Image, np.ndarray]:
+    def __call__(self, img: ImageOrNPArray) -> ImageOrNPArray:
         for filter_ in self.filters:
             img = filter_(img)
         return img
@@ -99,7 +98,9 @@ class Lambda(ImageFilter):
         assert callable(lambd), repr(type(lambd).__name__) + " object is not callable"
         self.lambd = lambd
 
-    def __call__(self, img: PIL.Image.Image) -> Union[PIL.Image.Image, np.ndarray]:
+    def __call__(self, img: ImageOrNPArray) -> ImageOrNPArray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
+
         return self.lambd(img)
 
 
@@ -117,7 +118,9 @@ class ToPILImage(Filter):
         The image represented as PIL Image
     """
 
-    def __call__(self, np_img: np.ndarray) -> PIL.Image.Image:
+    def __call__(self, np_img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(np_img, np.ndarray), "Input must be a numpy array"
+
         return util.np_to_pil(np_img)
 
 
@@ -137,10 +140,12 @@ class ApplyMaskImage(Filter):
         Image with the mask applied
     """
 
-    def __init__(self, img: PIL.Image.Image) -> None:
+    def __init__(self, img: ImageOrNPArray) -> None:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         self.img = img
 
-    def __call__(self, mask: np.ndarray) -> PIL.Image.Image:
+    def __call__(self, mask: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(mask, np.ndarray), "Mask must be a numpy array"
         return util.apply_mask_image(self.img, mask)
 
 
@@ -178,7 +183,8 @@ class Invert(ImageFilter):
         >>> image_inv_gray = invert(image_gray)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.invert(img)
 
 
@@ -204,8 +210,9 @@ class RgbToGrayscale(ImageFilter):
         >>> image_gray = rgb_to_grayscale(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
-        return PIL.ImageOps.grayscale(img)
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
+        return ImageOps.grayscale(img)
 
 
 class RgbToHed(ImageFilter):
@@ -232,7 +239,8 @@ class RgbToHed(ImageFilter):
         >>> image_hed = rgb_to_hed(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         hed = F.rgb_to_hed(img)
         return hed
 
@@ -270,11 +278,12 @@ class RgbToLab(ImageFilter):
         >>> image_lab = rgb_to_lab(image_rgb)
     """  # noqa
 
-    def __init__(self, illuminant: str = "D65", observer: int = "2") -> None:
+    def __init__(self, illuminant: str = "D65", observer: int = 2) -> None:
         self.illuminant = illuminant
         self.observer = observer
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         lab = F.rgb_to_lab(img, self.illuminant, self.observer)
         return lab
 
@@ -301,7 +310,8 @@ class RgbToOd(ImageFilter):
         >>> image_od = rgb_to_od(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         od = F.rgb_to_od(img)
         return od
 
@@ -328,7 +338,8 @@ class HedToRgb(ImageFilter):
         >>> rgb = hed_to_rgb(hed_arr)
     """  # noqa
 
-    def __call__(self, img_arr: np.array) -> PIL.Image.Image:
+    def __call__(self, img_arr: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img_arr, np.ndarray), "Input must be an ndarray"
         rgb = F.hed_to_rgb(img_arr)
         return rgb
 
@@ -358,7 +369,8 @@ class HematoxylinChannel(ImageFilter):
         >>> image_h = hematoxylin_channel(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         hematoxylin = F.hematoxylin_channel(img)
         return hematoxylin
 
@@ -388,7 +400,8 @@ class EosinChannel(ImageFilter):
         >>> image_e = eosin_channel(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         eosin = F.eosin_channel(img)
         return eosin
 
@@ -418,7 +431,8 @@ class DABChannel(ImageFilter):
         >>> image_d = dab_channel(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         dab = F.dab_channel(img)
         return dab
 
@@ -447,7 +461,8 @@ class RgbToHsv(ImageFilter):
         >>> image_hsv = rgb_to_hsv(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         hsv = F.rgb_to_hsv(img)
         return hsv
 
@@ -500,7 +515,8 @@ class StretchContrast(ImageFilter):
         self.low = low
         self.high = high
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         stretch_contrast = F.stretch_contrast(img, self.low, self.high)
         return stretch_contrast
 
@@ -569,7 +585,8 @@ class HistogramEqualization(ImageFilter):
     def __init__(self, n_bins: int = 256) -> None:
         self.n_bins = n_bins
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         hist_equ = F.histogram_equalization(img, self.n_bins)
         return hist_equ
 
@@ -623,7 +640,8 @@ class AdaptiveEqualization(ImageFilter):
         self.n_bins = n_bins
         self.clip_limit = clip_limit
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         adaptive_equ = F.adaptive_equalization(img, self.n_bins, self.clip_limit)
         return adaptive_equ
 
@@ -654,12 +672,12 @@ class LabToRgb(ImageFilter):
         >>> image_rgb = lab_to_rgb(arr_lab)
     """
 
-    def __init__(self, illuminant: str = "D65", observer: int = "2") -> None:
+    def __init__(self, illuminant: str = "D65", observer: int = 2) -> None:
         self.illuminant = illuminant
         self.observer = observer
 
-    def __call__(self, np_arr: np.ndarray) -> PIL.Image.Image:
-        lab = F.lab_to_rgb(np_arr, self.illuminant, self.observer)
+    def __call__(self, np_arr: ImageOrNPArray) -> PIL.Image.Image:
+        lab = F.lab_to_rgb(np_arr, self.illuminant, self.observer)  # type: ignore # excuse: np_arr should be an image # noqa
         return lab
 
 
@@ -693,7 +711,8 @@ class LocalEqualization(ImageFilter):
     def __init__(self, disk_size: int = 50) -> None:
         self.disk_size = disk_size
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         local_equ = F.local_equalization(img, self.disk_size)
         return local_equ
 
@@ -741,7 +760,8 @@ class KmeansSegmentation(ImageFilter):
         self.n_segments = n_segments
         self.compactness = compactness
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         kmeans_segmentation = F.kmeans_segmentation(
             img, self.n_segments, self.compactness
         )
@@ -810,9 +830,10 @@ class RagThreshold(ImageFilter):
 
     def __call__(
         self,
-        img: PIL.Image.Image,
+        img: ImageOrNPArray,
         mask: np.ndarray = None,
-    ) -> Union[PIL.Image.Image, np.ndarray]:
+    ) -> ImageOrNPArray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.rag_threshold(
             img,
             n_segments=self.n_segments,
@@ -865,7 +886,8 @@ class HysteresisThreshold(ImageFilter):
         self.low = low
         self.high = high
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.hysteresis_threshold(img, self.low, self.high)
 
 
@@ -903,7 +925,8 @@ class LocalOtsuThreshold(ImageFilter):
     def __init__(self, disk_size: float = 3.0) -> None:
         self.disk_size = disk_size
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.local_otsu_threshold(img, self.disk_size)
 
 
@@ -945,7 +968,8 @@ class HysteresisThresholdMask(ImageFilter):
         self.low = low
         self.high = high
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         hysteresis_threshold_mask = F.hysteresis_threshold_mask(
             img, self.low, self.high
         )
@@ -992,7 +1016,8 @@ class OtsuThreshold(ImageFilter):
         Trans SystMan Cybern Syst 9.1 (1979)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.otsu_threshold(img)
 
 
@@ -1041,7 +1066,8 @@ class FilterEntropy(ImageFilter):
         self.neighborhood = neighborhood
         self.threshold = threshold
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.filter_entropy(img, self.neighborhood, self.threshold)
 
 
@@ -1107,7 +1133,8 @@ class CannyEdges(ImageFilter):
         self.low_threshold = low_threshold
         self.high_threshold = high_threshold
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.canny_edges(img, self.sigma, self.low_threshold, self.high_threshold)
 
 
@@ -1142,7 +1169,8 @@ class Grays(ImageFilter):
     def __init__(self, tolerance: int = 15) -> None:
         self.tolerance = tolerance
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.grays(img, self.tolerance)
 
 
@@ -1198,7 +1226,8 @@ class GreenChannelFilter(ImageFilter):
         self.avoid_overmask = avoid_overmask
         self.overmask_thresh = overmask_thresh
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.green_channel_filter(
             img, self.green_thresh, self.avoid_overmask, self.overmask_thresh
         )
@@ -1213,7 +1242,7 @@ class RedFilter(ImageFilter):
 
     Parameters
     ----------
-    img : PIl.Image.Image
+    img : PIL.Image.Image
         Input RGB image
     red_lower_thresh : int
         Red channel lower threshold value.
@@ -1241,7 +1270,8 @@ class RedFilter(ImageFilter):
         self.green_thresh = green_thresh
         self.blue_thresh = blue_thresh
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.red_filter(img, self.red_thresh, self.green_thresh, self.blue_thresh)
 
 
@@ -1270,7 +1300,8 @@ class RedPenFilter(ImageFilter):
         >>> image_no_red = red_pen_filter(image_rgb)
     """
 
-    def __call__(self, img: PIL.Image.Image):
+    def __call__(self, img: ImageOrNPArray):
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.red_pen_filter(img)
 
 
@@ -1284,7 +1315,7 @@ class GreenFilter(ImageFilter):
 
     Parameters
     ----------
-    img : PIL.image.Image
+    img : PIL.Image.Image
         RGB input image.
     red_thresh : int
         Red channel upper threshold value.
@@ -1343,7 +1374,8 @@ class GreenPenFilter(ImageFilter):
         >>> image_no_green = green_pen_filter(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.green_pen_filter(img)
 
 
@@ -1356,7 +1388,7 @@ class BlueFilter(ImageFilter):
 
     Parameters
     ----------
-    img : PIl.Image.Image
+    img : PIL.Image.Image
         Input RGB image
     red_thresh : int
         Red channel lower threshold value.
@@ -1384,7 +1416,8 @@ class BlueFilter(ImageFilter):
         self.green_thresh = green_thresh
         self.blue_thresh = blue_thresh
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.blue_filter(img, self.red_thresh, self.green_thresh, self.blue_thresh)
 
 
@@ -1413,7 +1446,8 @@ class BluePenFilter(ImageFilter):
         >>> image_no_blue = blue_pen_filter(image_rgb)
     """  # noqa
 
-    def __call__(self, img: PIL.Image.Image) -> PIL.Image.Image:
+    def __call__(self, img: ImageOrNPArray) -> PIL.Image.Image:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.blue_pen_filter(img)
 
 
@@ -1471,5 +1505,6 @@ class YenThreshold(ImageFilter):
     def __init__(self, relate: Callable[..., Any] = operator.lt):
         self.relate = relate
 
-    def __call__(self, img: PIL.Image.Image) -> np.ndarray:
+    def __call__(self, img: ImageOrNPArray) -> np.ndarray:
+        assert isinstance(img, PIL.Image.Image), "Input must be an image"
         return F.yen_threshold(img, self.relate)

--- a/histolab/filters/morphological_filters.py
+++ b/histolab/filters/morphological_filters.py
@@ -24,10 +24,8 @@ import skimage.morphology
 from . import morphological_filters_functional as F
 from .image_filters import Filter
 
-try:
-    from typing import Protocol, runtime_checkable
-except ImportError:
-    from typing_extensions import Protocol, runtime_checkable
+
+from typing_extensions import Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/histolab/tile.py
+++ b/histolab/tile.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
-from PIL import Image
+import PIL.Image
 
 from .filters import image_filters as imf
 from .filters.compositions import FiltersComposition
@@ -34,7 +34,7 @@ class Tile:
 
     Arguments
     ---------
-    image : Image.Image
+    image : PIL.Image.Image
         Image describing the tile
     coords : CoordinatePair
         Level 0 Coordinates of the Slide from which the tile was extracted
@@ -44,7 +44,7 @@ class Tile:
 
     def __init__(
         self,
-        image: Image.Image,
+        image: PIL.Image.Image,
         coords: CoordinatePair,
         level: Optional[int] = None,
     ):
@@ -70,7 +70,7 @@ class Tile:
         """
         filtered_image = filters(self.image)
         if isinstance(filtered_image, np.ndarray):
-            filtered_image = Image.fromarray(filtered_image)
+            filtered_image = PIL.Image.fromarray(filtered_image)
         return Tile(filtered_image, self.coords, self.level)
 
     @lazyproperty
@@ -125,12 +125,12 @@ class Tile:
         return True
 
     @lazyproperty
-    def image(self) -> Image.Image:
+    def image(self) -> PIL.Image.Image:
         """Image describing the tile.
 
         Returns
         -------
-        Image.Image
+        PIL.Image.Image
             Image describing the tile.
         """
         return self._image
@@ -201,7 +201,7 @@ class Tile:
             constant_values=255,
         )
 
-        tile_border = Image.fromarray(np_tile_border)
+        tile_border = PIL.Image.fromarray(np_tile_border)
 
         # apply filters on tile with border
         filters = FiltersComposition(Tile).tissue_mask_filters

--- a/histolab/tile.py
+++ b/histolab/tile.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
-import PIL
+from PIL import Image
 
 from .filters import image_filters as imf
 from .filters.compositions import FiltersComposition
@@ -34,7 +34,7 @@ class Tile:
 
     Arguments
     ---------
-    image : PIL.Image.Image
+    image : Image.Image
         Image describing the tile
     coords : CoordinatePair
         Level 0 Coordinates of the Slide from which the tile was extracted
@@ -44,7 +44,7 @@ class Tile:
 
     def __init__(
         self,
-        image: PIL.Image.Image,
+        image: Image.Image,
         coords: CoordinatePair,
         level: Optional[int] = None,
     ):
@@ -70,7 +70,7 @@ class Tile:
         """
         filtered_image = filters(self.image)
         if isinstance(filtered_image, np.ndarray):
-            filtered_image = PIL.Image.fromarray(filtered_image)
+            filtered_image = Image.fromarray(filtered_image)
         return Tile(filtered_image, self.coords, self.level)
 
     @lazyproperty
@@ -125,18 +125,18 @@ class Tile:
         return True
 
     @lazyproperty
-    def image(self) -> PIL.Image.Image:
+    def image(self) -> Image.Image:
         """Image describing the tile.
 
         Returns
         -------
-        PIL.Image.Image
+        Image.Image
             Image describing the tile.
         """
         return self._image
 
     @lazyproperty
-    def level(self) -> int:
+    def level(self) -> Optional[int]:
         """Level of tile extraction.
 
         Returns
@@ -150,7 +150,7 @@ class Tile:
         """Save tile at given path.
 
         The format to use is determined from the filename extension (to be compatible to
-        PIL.Image formats). If no extension is provided, the image will be saved in png
+        Image formats). If no extension is provided, the image will be saved in png
         format.
 
         Parameters
@@ -159,12 +159,16 @@ class Tile:
             Path to which the tile is saved.
 
         """
+
+        if isinstance(path, bytes):
+            path = path.decode("utf-8")
+
         ext = os.path.splitext(path)[1]
         if not ext:
             path = f"{path}.png"
 
         Path(path).parent.mkdir(parents=True, exist_ok=True)
-        self._image.save(path)
+        self._image.save(str(path))
 
     @lazyproperty
     def tissue_mask(self) -> np.ndarray:
@@ -197,7 +201,7 @@ class Tile:
             constant_values=255,
         )
 
-        tile_border = PIL.Image.fromarray(np_tile_border)
+        tile_border = Image.fromarray(np_tile_border)
 
         # apply filters on tile with border
         filters = FiltersComposition(Tile).tissue_mask_filters

--- a/histolab/util.py
+++ b/histolab/util.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, List, Tuple
 
 import numpy as np
 import PIL
+import PIL.Image
 import PIL.ImageDraw
 from skimage.measure import label, regionprops
 from skimage.util.dtype import img_as_ubyte
@@ -157,7 +158,10 @@ def regions_from_binary_mask(binary_mask: np.ndarray) -> List[Region]:
     def convert_np_coords_to_pil_coords(
         bbox_np: Tuple[int, int, int, int]
     ) -> Tuple[int, int, int, int]:
-        return (*reversed(bbox_np[:2]), *reversed(bbox_np[2:]))
+        x_ul, y_ul = reversed(bbox_np[:2])
+        x_br, y_br = reversed(bbox_np[2:])
+
+        return (x_ul, y_ul, x_br, y_br)
 
     thumb_labeled_regions = label(binary_mask)
     regions = [
@@ -242,11 +246,11 @@ def scale_coordinates(
     coords: CoordinatesPair
         Coordinates in the scaled image
     """
-    reference_coords = np.asarray(reference_coords).ravel()
-    reference_size = np.tile(reference_size, 2)
-    target_size = np.tile(target_size, 2)
+    _reference_coords = np.asarray(reference_coords).ravel()
+    _reference_size = np.tile(reference_size, 2)
+    _target_size = np.tile(target_size, 2)
     return CoordinatePair(
-        *np.floor((reference_coords * target_size) / reference_size).astype("int64")
+        *np.floor((_reference_coords * _target_size) / _reference_size).astype("int64")
     )
 
 
@@ -351,6 +355,6 @@ def method_dispatch(func: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(*args, **kw):
         return dispatcher.dispatch(args[1].__class__)(*args, **kw)
 
-    wrapper.register = dispatcher.register
+    setattr(wrapper, "register", dispatcher.register)
     functools.update_wrapper(wrapper, func)
     return wrapper

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,23 @@
+[mypy]
+python_version = 3.10
+; warn_return_any = True
+; warn_unused_configs = True
+; strict = True
+
+[mypy-openslide]
+ignore_missing_imports = True
+
+[mypy-pooch]
+ignore_missing_imports = True
+
+[mypy-skimage]
+ignore_missing_imports = True
+
+[mypy-skimage.*]
+ignore_missing_imports = True
+
+[mypy-scipy]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,6 @@ black
 sphinxemoji
 sphinx-prompt
 bandit
+mypy
+types-requests
+types-pillow


### PR DESCRIPTION
This PR attemps to fix some of (or all) the typing issues found by running `mypy histolab`.

Unfortunately some of these issues are hard to fix without context and without making a design decision. I've left a couple of TODOs in the code for that.

The biggest issue is having `class Filter(Protocol)` that has a call method that accepts either an image or a ndarray, unfortunaly mypy doesn't allow to change the argument type to a more specific one (see https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides). Maybe we should have two types of Filters, one for images and one for ndarrays.

Also, I'm not 100% convinced Protocol is useful here (and in the Tiler class), what's the reasoning behind using Protocol and not abc.ABC?
