### PR TITLE
Fix bug of thumbnail dimensions when using large_image

### DIFF
--- a/histolab/slide.py
+++ b/histolab/slide.py
@@ -497,7 +497,11 @@ class Slide:
             The slide thumbnail.
         """
         if self._use_largeimage:
-            thumb_bytes, _ = self._tile_source.getThumbnail(encoding="PNG")
+            thumb_bytes, _ = self._tile_source.getThumbnail(
+                encoding="PNG",
+                width=self._thumbnail_size[0],
+                height=self._thumbnail_size[1],
+            )
             thumbnail = self._bytes2pil(thumb_bytes).convert("RGB")
             return thumbnail
 

--- a/tests/integration/test_slide.py
+++ b/tests/integration/test_slide.py
@@ -244,3 +244,14 @@ class Describe_Slide:
 
         assert isinstance(properties, dict)
         assert properties == load_python_expression("python-expr/slide_properties_dict")
+
+    @pytest.mark.parametrize("use_largeimage", [True, False])
+    def it_knows_its_thumbnail(self, use_largeimage):
+        slide = Slide(
+            SVS.CMU_1_SMALL_REGION, "processed", use_largeimage=use_largeimage
+        )
+
+        thumbnail = slide.thumbnail
+
+        assert isinstance(thumbnail, PIL.Image.Image)
+        assert thumbnail.size == (221, 296)

--- a/tests/unit/test_slide.py
+++ b/tests/unit/test_slide.py
@@ -9,7 +9,6 @@ import numpy as np
 import openslide
 import PIL
 import pytest
-from large_image.exceptions import TileSourceException
 from PIL import ImageShow
 
 from histolab.exceptions import LevelError, MayNeedLargeImageError, SlidePropertyError
@@ -252,20 +251,15 @@ class Describe_Slide:
         assert type(resampled_array) == np.ndarray
         assert resampled_array.shape == (400, 300, 3)
 
-    def it_knows_its_thumbnail_size(self, tmpdir):
-        slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240)
+    @pytest.mark.parametrize("use_largeimage", [True, False])
+    def it_knows_its_thumbnail_size(self, tmpdir, use_largeimage):
+        slide, _ = base_test_slide(
+            tmpdir, PILIMG.RGBA_COLOR_500X500_155_249_240, use_largeimage=use_largeimage
+        )
 
         thumb_size = slide._thumbnail_size
 
         assert thumb_size == (500, 500)
-
-    def it_raises_error_if_thumbnail_size_and_use_largeimage(self):
-        slide = Slide("/a/b/foo", "processed", use_largeimage=True)
-
-        with pytest.raises(TileSourceException) as err:
-            slide._thumbnail_size
-
-        assert str(err.value) == "No available tilesource for /a/b/foo"
 
     def it_creates_a_correct_slide_object(self, tmpdir):
         slide, _ = base_test_slide(tmpdir, PILIMG.RGBA_COLOR_50X50_155_0_0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
Now the thumbnail dimension is the same when using openslide or large_image as backend

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Fixes: #385

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/histolab/histolab/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
