### PR TITLE
Add relate parameter to Otsuthreshold

### DIFF
--- a/histolab/filters/image_filters.py
+++ b/histolab/filters/image_filters.py
@@ -969,6 +969,9 @@ class OtsuThreshold(ImageFilter):
     ----------
     img : PIL.Image.Image
         Input image.
+    relate : operator, optional
+        Operator to be used to compute the mask from the threshold. Default is
+        operator.lt
 
     Returns
     -------
@@ -992,8 +995,11 @@ class OtsuThreshold(ImageFilter):
         Trans SystMan Cybern Syst 9.1 (1979)
     """  # noqa
 
+    def __init__(self, relate: Callable[..., Any] = operator.lt):
+        self.relate = relate
+
     def __call__(self, img: PIL.Image.Image) -> np.ndarray:
-        return F.otsu_threshold(img)
+        return F.otsu_threshold(img, self.relate)
 
 
 class FilterEntropy(ImageFilter):

--- a/tests/unit/filters/test_image_filters.py
+++ b/tests/unit/filters/test_image_filters.py
@@ -224,7 +224,7 @@ class DescribeImageFilters:
 
         otsu_threshold(image)
 
-        F_otsu_threshold.assert_called_once_with(image)
+        F_otsu_threshold.assert_called_once_with(image, operator.lt)
         assert type(otsu_threshold(image)) == np.ndarray
 
     def it_calls_local_otsu_threshold_functional(self, request):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This is related to [OtsuThreshold is missing the relate parameter #403](https://github.com/histolab/histolab/issues/403).
Adds a relate parameter to be passed to image_filters.OtsuThreshold class.

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Added relate arguments in __init__, and call functional otsu_threshold with.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* Fixes: [#403](https://github.com/histolab/histolab/issues/403).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
**I just changed the function documentation.**
- [x] I have read the [CONTRIBUTING](https://github.com/histolab/histolab/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
